### PR TITLE
Allow custom restart command and fix regression

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,27 +108,27 @@ acme_tiny__service_map:
   apache2:
     cert_format: 'chain'
     cert_directory: '/etc/apache2/ssl'
-    service_name: 'apache2'
+    restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart apache2'
   dovecot:
     cert_format: 'chain'
     cert_directory: '/etc/dovecot/ssl'
-    service_name: 'dovecot'
+    restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart dovecot'
   httpd:
     cert_format: 'chain'
     cert_directory: '/etc/httpd/ssl'
-    service_name: 'httpd'
+    restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart httpd'
   lighttpd:
     cert_format: 'keycert'
     cert_directory: '/etc/lighttpd/ssl'
-    service_name: 'lighttpd'
+    restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart lighttpd'
   nginx:
     cert_format: 'chain'
     cert_directory: '/etc/nginx/ssl'
-    service_name: 'nginx'
+    restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart nginx'
   postfix:
     cert_format: 'chain'
     cert_directory: '/etc/postfix/ssl'
-    service_name: 'postfix'
+    restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart postfix'
 
 
 # .. envvar:: acme_tiny__service_restart

--- a/docs/system-configuration.rst
+++ b/docs/system-configuration.rst
@@ -144,8 +144,10 @@ name as key and needs to define the following properties:
   Custom directory from where the certificate and key will be symlinked.
   See :ref:`acme_tiny_ref_fs_layout` for more details.
 
-``service_name``
-  Name of the service which needs to be restarted after certificate renewal.
+``restart_command``
+  Command which should be executed to restart this service (instance) as an
+  unprivileged user. If this command contains :program:`sudo`, a corresponding
+  rule will be created for the :envvar:`acme_tiny__user_name` account.
 
 *Example*
 
@@ -157,7 +159,7 @@ Custom Ansible inventory definition for `Pound <http://www.apsis.ch/pound>`_:
       pound:
         cert_format: 'keycert'
         cert_directory: '/etc/pound/ssl'
-        service_name: 'pound'
+        restart_command: '/usr/bin/sudo -n /usr/bin/systemctl restart pound'
 
 
 .. _acme_tiny_ref_cert_renewal:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,9 +55,10 @@
                   else [ acme_tiny__service ] }}'
 
 - name: Restart service
-  command: sudo -n /usr/bin/systemctl restart '{{ item }}'
+  command: '{{ acme_tiny__service_map[item].restart_command }}'
   register: acme_tiny__register_service_restart
-  when: (item | length > 0) and
+  when: (item in acme_tiny__service_map|d({})) and
+        ("restart_command" in acme_tiny__service_map[item]) and
         (acme_tiny__register_certificate | changed) and
         (acme_tiny__service_restart|d(True))
   with_items: '{{ acme_tiny__service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,9 @@
   file:
     path: '{{ acme_tiny__cert_dir }}/{{ acme_tiny__cert_name }}_keycert.pem'
     mode: '0600'
+  when: (item in acme_tiny__service_map|d({})) and
+        ("cert_format" in acme_tiny__service_map[item]) and
+        (acme_tiny__service_map[item].cert_format == "keycert")
 
 - name: Merge certificate chain
   become: True

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -98,3 +98,17 @@
   include: setup_links.yml
   when: acme_tiny__symlinks|d(True) and
         acme_tiny__service|d()
+
+- name: Sudo rule for service restart
+  template:
+    src: sudoers.d-rule.j2
+    dest: '/etc/sudoers.d/{{ acme_tiny__user_name }}-{{ item }}-{{ acme_tiny__cert_name }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+  when: (item in acme_tiny__service_map|d({})) and
+        ("restart_command" in acme_tiny__service_map[item]) and
+        (acme_tiny__service_map[item].restart_command | search("sudo"))
+  with_items: '{{ acme_tiny__service
+                  if acme_tiny__service is iterable and not acme_tiny__service is string
+                  else [ acme_tiny__service ] }}'

--- a/templates/sudoers.d-rule.j2
+++ b/templates/sudoers.d-rule.j2
@@ -1,4 +1,4 @@
 {{ ansible_managed | comment }}
 
 # Allow restart of {{ item }} after certificate update
-{{ acme_tiny__user_name }} ALL=(root) NOPASSWD: /usr/bin/systemctl restart {{ item }}
+{{ acme_tiny__user_name }} ALL=(root) NOPASSWD: {{ acme_tiny__service_map[item].restart_command | regex_replace("(.*bin/)?sudo( -[-A-Za-z]+)* ", "") }}


### PR DESCRIPTION
Unfortunately the `rolespec` assertion didn't catch the playbook failure when introducing a regression in 798ab3c therefore I add the fix here. The following issue nickjj/rolespec#41 was opened.