### PR TITLE
Valdate certificate before overwriting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,26 @@ The current role maintainer is `ganto <ganto@linuxmonk.ch>`_.
 `ganto.acme_tiny master`_ - unreleased
 --------------------------------------
 
-.. _ganto.acme_tiny master: https://github.com/ganto/ansible-acme_tiny/compare/v0.1.1...master
+.. _ganto.acme_tiny master: https://github.com/ganto/ansible-acme_tiny/compare/v0.1.2...master
+
+
+`ganto.acme_tiny v0.1.2`_ - 2019-09-07
+--------------------------------------
+
+.. _ganto.acme_tiny v0.1.2: https://github.com/ganto/ansible-acme_tiny/compare/v0.1.0...v0.1.2
+
+Added
+~~~~~
+
+- New variable :envvar:`acme_tiny__cert_backup` allows to disable backup of
+  existing certificates. Defaults to ``True``.
+
+Changed
+~~~~~~~
+
+- Don't overwrite existing certificate when running ``acme-tiny``. First create a
+  temporary file and only copy certificate in place after validation.
+
 
 `ganto.acme_tiny v0.1.1`_ - 2018-09-23
 --------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,13 @@ acme_tiny__challenge_dir: '/var/www/acme-challenges'
 # :ref:`acme_tiny_ref_account_key`.
 acme_tiny__account_key: 'account.key'
 
+
+# .. envvar:: acme_tiny__cert_backup
+#
+# If a certificate already exists create a backup before overwriting it with
+# the re-newed certificate.
+acme_tiny__cert_backup: True
+
                                                                    # ]]]
 # Certificate authority configuration [[[
 # ---------------------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,22 +13,32 @@
     --directory-url '{{ acme_tiny__ca_directory_url }}'
     --account-key '{{ acme_tiny__config_dir }}/{{ acme_tiny__account_key }}'
     --csr '{{ acme_tiny__cert_request }}'
-    --acme-dir '{{ acme_tiny__challenge_dir }}' > '{{ acme_tiny__certificate }}'
+    --acme-dir '{{ acme_tiny__challenge_dir }}' > '{{ acme_tiny__certificate }}.tmp'
   register: acme_tiny__register_certificate
   failed_when: False
 
 - name: Show acme-tiny output
-  debug: var=acme_tiny__register_certificate
+  debug:
+    var: acme_tiny__register_certificate
   when: not ansible_check_mode|d()
   failed_when: ("rc" in acme_tiny__register_certificate) and
                (not acme_tiny__register_certificate.rc == 0)
 
-- name: Certificate permissions
-  file:
-    path: '{{ acme_tiny__certificate }}'
+- name: Copy certificate from temporary file
+  copy:
+    src: '{{ acme_tiny__certificate }}.tmp'
+    dest: '{{ acme_tiny__certificate }}'
     owner: '{{ acme_tiny__user_name }}'
     group: '{{ acme_tiny__user_group }}'
     mode: '0644'
+    backup: '{{ acme_tiny__cert_backup }}'
+    remote_src: True
+    validate: /usr/bin/openssl x509 -in %s -noout -text
+
+- name: Cleanup temporary file
+  file:
+    path: '{{ acme_tiny__certificate }}.tmp'
+    state: absent
 
 - name: Merge certificate/key to PEM file
   become: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,8 @@
                (not acme_tiny__register_certificate.rc == 0)
 
 - name: Copy certificate from temporary file
+  become: True
+  become_user: '{{ acme_tiny__user_name }}'
   copy:
     src: '{{ acme_tiny__certificate }}.tmp'
     dest: '{{ acme_tiny__certificate }}'
@@ -36,6 +38,8 @@
     validate: /usr/bin/openssl x509 -in %s -noout -text
 
 - name: Cleanup temporary file
+  become: True
+  become_user: '{{ acme_tiny__user_name }}'
   file:
     path: '{{ acme_tiny__certificate }}.tmp'
     state: absent


### PR DESCRIPTION
So far the `acme-tiny` output has been overwriting existing certificates during execution. This resulted in an empty file if the command failed. This meant that a valid certificate was replaced with an empty file resulting in a denial of service on restart of most TLS services depending on that certificate.

Now we will write the new certificate in a temporary file, validate it to be a x509 certificate and then only overwrite the old certificate. Additionally a backup copy of the old certificate is made by default.