### PR TITLE
ansible 2.9: fix template error: "no filter named 'search'"

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -104,7 +104,7 @@
     mode: '0440'
   when: (item in acme_tiny__service_map|d({})) and
         ("restart_command" in acme_tiny__service_map[item]) and
-        (acme_tiny__service_map[item].restart_command | search("sudo"))
+        (acme_tiny__service_map[item].restart_command is search("sudo"))
   with_items: '{{ acme_tiny__service
                   if acme_tiny__service is iterable and not acme_tiny__service is string
                   else [ acme_tiny__service ] }}'


### PR DESCRIPTION
As of ansible 2.9 is a test, but not a filter, and it throws this error:

```
fatal: [vno1]: FAILED! => {"msg": "The conditional check '(item in acme_tiny__service_map|d({})) and (\"restart_command\" in acme_tiny__service_map[item]) and (acme_tiny__service_map[item].restart_command | search(\"sudo\"))' failed. The error was: template error while templating string: no filter named 'search'. <...>
```

Identical to https://github.com/kubernetes-sigs/image-builder/issues/92
and https://github.com/chesterbr/chester-ansible-configs/commit/32827b764dc2cb0eead11d9b446bdfa32f5ec0ad.

Ansible version: 2.9.6+dfsg-1 on Ubuntu 20.04.